### PR TITLE
Proposed Change we need to use mime type audio/aac

### DIFF
--- a/Audio Trimmer/app/src/main/java/com/demo/audiotrimmer/customAudioViews/SoundFile.java
+++ b/Audio Trimmer/app/src/main/java/com/demo/audiotrimmer/customAudioViews/SoundFile.java
@@ -502,7 +502,7 @@ public class SoundFile {
         // Some devices have problems reading mono AAC files (e.g. Samsung S3). Making it stereo.
         int numChannels = (mChannels == 1) ? 2 : mChannels;
 
-        String mimeType = "audio/mp4a-latm";
+        String mimeType = "audio/aac";
         int bitrate = 64000 * numChannels;  // rule of thumb for a good quality: 64kbps per channel.
         MediaCodec codec = MediaCodec.createEncoderByType(mimeType);
         MediaFormat format = MediaFormat.createAudioFormat(mimeType, mSampleRate, numChannels);


### PR DESCRIPTION
the logic behind this the previous mime was able to cut and save the ringtone without any issue but when we use to load the trim file through code it give an exception suppose take an example where you need to merge the trim audio to video you will get an exception of illegal state as the mime type is wrong